### PR TITLE
fix deprecated HSPI_HOST and VSPI_HOST

### DIFF
--- a/src/lcd_hal/esp/esp32_spi.h
+++ b/src/lcd_hal/esp/esp32_spi.h
@@ -41,7 +41,7 @@ class EspSpi
 public:
     /**
      * Creates instance of spi implementation for ESP platform
-     * @param busId number of SPI bus to use: HSPI_HOST, VSPI_HOST
+     * @param busId number of SPI bus to use: SPI2_HOST, SPI3_HOST (formerly HSPI_HOST, VSPI_HOST)
      * @param csPin pin number to use as chip select, can be -1
      * @param dcPin pin to use as data command control pin
      * @param clk pin to use as clock spi pin
@@ -89,7 +89,7 @@ public:
     void sendBuffer(const uint8_t *buffer, uint16_t size);
 
 private:
-    int8_t m_busId;
+    spi_host_device_t m_busId;
     int8_t m_cs;
     int8_t m_dc;
     int8_t m_clk;


### PR DESCRIPTION
Should fix #95, at least it compiles as an IDF v4.4 component.
This PR is quite straightforward, but be aware I was not able to test for regressions on real SPI oled hardware.

Another busId mapping would be busId valid values 2 and 3, because SPI0_HOST is not software-accessible and SPI1_HOST is not easily available as general purpose SPI controller.
Using the same numbering scheme as in official ESP documentation would be more intuitive.
But such a change in ldcgfx API is likely to break existing projects.

So i tried to keep the same mapping : 
busId=0 -> HSPI_HOST, now SPI2_HOST
busId=1 -> VSPI_HOST, now SPI3_HOST  (default)

@Lexus2K : this is up to you

