### PR TITLE
Enable TwoWire pin configuration for stm32

### DIFF
--- a/src/lcd_hal/arduino/arduino_wire.cpp
+++ b/src/lcd_hal/arduino/arduino_wire.cpp
@@ -50,13 +50,18 @@ ArduinoI2c::~ArduinoI2c()
 
 void ArduinoI2c::begin()
 {
-#if defined(ESP8266) || defined(ESP32) || defined(ESP31B)
     if ( (m_scl >= 0) && (m_sda >= 0) )
     {
+#if defined(ESP8266) || defined(ESP32) || defined(ESP31B)
         Wire.begin(m_sda, m_scl);
+#elif defined(ARDUINO_ARCH_STM32)
+        // Wire.begin(m_sda, m_scl) does not work for stm32duino core
+        Wire.setSCL(m_scl);
+        Wire.setSDA(m_sda);
+        Wire.begin();
+#endif
     }
     else
-#endif
     {
         Wire.begin();
     }


### PR DESCRIPTION
This change allows i2c displays to work with non-default i2c pins on STM32.
Tested on custom board with STM32F072C8T6 and SH1106 128x64 display with I2C2 peripheral on PB10 and PB11