### PR TITLE
make it compile-able for esp8266

### DIFF
--- a/src/lcd_hal/esp/esp32_spi.cpp
+++ b/src/lcd_hal/esp/esp32_spi.cpp
@@ -24,7 +24,7 @@
 
 #include "../io.h"
 
-#if defined(CONFIG_ESP32_SPI_AVAILABLE) && defined(CONFIG_ESP32_SPI_ENABLE)
+#if defined(CONFIG_ESP32_SPI_AVAILABLE) && defined(CONFIG_ESP32_SPI_ENABLE) && defined(ESP32)
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/src/lcd_hal/esp/esp32_spi.h
+++ b/src/lcd_hal/esp/esp32_spi.h
@@ -29,7 +29,7 @@
 #ifndef _SSD1306V2_ESP_ESP32_SPI_H_
 #define _SSD1306V2_ESP_ESP32_SPI_H_
 
-#if defined(CONFIG_ESP32_SPI_AVAILABLE) && defined(CONFIG_ESP32_SPI_ENABLE)
+#if defined(CONFIG_ESP32_SPI_AVAILABLE) && defined(CONFIG_ESP32_SPI_ENABLE) && defined(ESP32)
 
 #include "driver/spi_master.h"
 


### PR DESCRIPTION
Somehow the compiler wasn't happy with the non-existent inclusions that meant for esp32, while targetting esp8266. This PR will just fix that, it's already tested for compiling both esp32 and esp8266 in Arduino IDE 2.1.1