### PR TITLE
Adding a library.json file to fix platformio for ESP-IDF

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,10 @@
+{
+    "name": "lcdgfx",
+    "description": "VGA, SSD1306, SSD1331, SSD1325/SSD1327, SSD1351, IL9163/ST7735, ST7789, ILI9341, PCD8544, SH1106/SH1107 spi/i2c OLED/LED Display driver.",
+    "version": "1.1.5",
+    "repository":
+    {
+       "type": "git",
+       "url": "https://github.com/lexus2k/lcdgfx"
+    }
+ }


### PR DESCRIPTION
This repo cannot directly be included from platformio vscode plugin because lacks a `library.json` file.
The platformio introspection detects the presence of `library.properties` and `keywords.txt` files determining it is an arduino package. That makes it fail in the ESP-IDF environment.

As a workaround I'm using a [prebuild script](https://gist.github.com/MiguelBarro/70b3ae7b226be729a6d5bf6b559916ec) but it will be more convenient to avoid the nuisance.