### PR TITLE
Fix integer overflow for framerates less than 4 fps

### DIFF
--- a/src/v2/nano_engine/core.h
+++ b/src/v2/nano_engine/core.h
@@ -250,7 +250,7 @@ public:
 
 protected:
     /** Duration between frames in milliseconds */
-    uint8_t m_frameDurationMs = 1000 / ENGINE_DEFAULT_FPS;
+    uint16_t m_frameDurationMs = 1000 / ENGINE_DEFAULT_FPS;
     /** Current fps */
     uint8_t m_fps = ENGINE_DEFAULT_FPS;
     /** Current cpu load in percents */


### PR DESCRIPTION
This increases m_FrameDurationMs from 8 to 16 bits.

Using 8 bits for m_FrameDurationMs meant it would overflow above 255ms, so attempting to use framerates below 4 would trigger frame refreshes too often.