### PR TITLE
Raspberry Pi Pico HAL

### DIFF
--- a/examples/pico_CMake_setup/CMakeLists.txt
+++ b/examples/pico_CMake_setup/CMakeLists.txt
@@ -1,0 +1,75 @@
+# Generated Cmake Pico project file
+
+cmake_minimum_required(VERSION 3.13)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Initialise pico_sdk from installed location
+# (note this can come from environment, CMake cache etc)
+
+# == DO NEVER EDIT THE NEXT LINES for Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+   set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(PICO_SDK_PATH ${USERHOME}/.pico-sdk/sdk/1.5.1)
+set(PICO_TOOLCHAIN_PATH ${USERHOME}/.pico-sdk/toolchain/13_2_Rel1)
+if(WIN32)
+    set(pico-sdk-tools_DIR ${USERHOME}/.pico-sdk/tools/1.5.1)
+    include(${pico-sdk-tools_DIR}/pico-sdk-tools-config.cmake)
+    include(${pico-sdk-tools_DIR}/pico-sdk-tools-config-version.cmake)
+endif()
+# ====================================================================================
+set(PICO_BOARD pico CACHE STRING "Board type")
+
+# Pull in Raspberry Pi Pico SDK (must be before project)
+include(pico_sdk_import.cmake)
+
+if (PICO_SDK_VERSION_STRING VERSION_LESS "1.4.0")
+  message(FATAL_ERROR "Raspberry Pi Pico SDK version 1.4.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
+endif()
+
+project(MyProject C CXX ASM)
+
+# Initialise the Raspberry Pi Pico SDK
+pico_sdk_init()
+
+# Add executable. Default name is the project name, version 0.1
+
+add_executable(MyProject MyProject.cpp )
+
+pico_set_program_name(MyProject "MyProject")
+pico_set_program_version(MyProject "0.1")
+
+# Modify the below lines to enable/disable output over UART/USB
+pico_enable_stdio_uart(MyProject 0)
+pico_enable_stdio_usb(MyProject 0)
+
+# Add the standard library to the build
+target_link_libraries(MyProject
+        pico_stdlib)
+
+# Add the standard include files to the build
+target_include_directories(MyProject PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}
+  ${CMAKE_CURRENT_LIST_DIR}/.. # for our common lwipopts or any other standard includes, if required
+)
+
+pico_add_extra_outputs(MyProject)
+
+# ====================================================================================
+# Add LCDGFX library CMakeLists.txt
+#target_compile_definitions(lcdgfx PUBLIC PICO_BOARD=${PICO_BOARD})
+add_subdirectory(lcdgfx)
+# Linke required pico libraries to lcdgfx
+target_link_libraries(lcdgfx
+        pico_stdlib pico_malloc pico_mem_ops
+        hardware_spi)
+
+# Add lcdgfx header files to MyProject
+target_include_directories(MyProject PRIVATE lcdgfx/src)
+# Link lcdgfx to MyProject
+target_link_libraries(MyProject lcdgfx)

--- a/examples/pico_CMake_setup/MyProject.cpp
+++ b/examples/pico_CMake_setup/MyProject.cpp
@@ -12,13 +12,17 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
 
-// Pin definitions for OLED
+// Pin definitions for OLED display
+// NOTE: SCK & MOSI pins must be one of the hardware peripheral SPI pins
 #define OLED_RST 3
 #define OLED_DC 2
 #define OLED_CS 5
 #define OLED_SCK 18
 #define OLED_MOSI 19
 #define SPI_FREQ 0 // 0 means default frequency
+
+// spi0 is used by default, to use spi1 uncomment the following line:
+//#define PICO_USE_SPI1
 
 // Include lcdgfx and use like for Arduino
 #include "lcdgfx.h"

--- a/examples/pico_CMake_setup/MyProject.cpp
+++ b/examples/pico_CMake_setup/MyProject.cpp
@@ -1,0 +1,41 @@
+/* This is an example for the microcontroller Raspberry Pi Pico
+ * Simply create a C/C++ project with "New Project" wizzard to create a:
+    * - CMakeLists.txt
+    * - MyProject.cpp
+    * - pico_sdk_import.cmake
+ * Now clone the lcdgfx library into the project folder.
+ * Modify the CMakeLists.txt to include the lcdgfx library (check the last 4 commands of this example)
+ * And use the library like for Arduino.
+ * 
+ * When the Pico project is build, CMake will also automatically compile and link the lcdgfx library.
+ */
+#include <stdio.h>
+#include "pico/stdlib.h"
+
+// Pin definitions for OLED
+#define OLED_RST 3
+#define OLED_DC 2
+#define OLED_CS 5
+#define OLED_SCK 18
+#define OLED_MOSI 19
+#define SPI_FREQ 0 // 0 means default frequency
+
+// Include lcdgfx and use like for Arduino
+#include "lcdgfx.h"
+DisplaySSD1306_128x64_SPI oled(OLED_RST, {-1, OLED_CS, OLED_DC, SPI_FREQ, OLED_SCK, OLED_MOSI});
+
+
+int main()
+{
+    stdio_init_all();
+
+    oled.begin();
+    oled.setFixedFont( ssd1306xled_font6x8 );
+    oled.clear();
+    oled.printFixed(0,  0, "Normal text", STYLE_NORMAL);
+    
+    while (true) {
+        printf("Hello, world!\n");
+        sleep_ms(1000);
+    }
+}

--- a/examples/pico_CMake_setup/pico_sdk_import.cmake
+++ b/examples/pico_CMake_setup/pico_sdk_import.cmake
@@ -1,0 +1,73 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        # GIT_SUBMODULES_RECURSE was added in 3.17
+        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+                    GIT_SUBMODULES_RECURSE FALSE
+            )
+        else ()
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+            )
+        endif ()
+
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            FetchContent_Populate(pico_sdk)
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/src/lcd_hal/io.h
+++ b/src/lcd_hal/io.h
@@ -89,6 +89,12 @@
 #include "linux/sdl_i2c.h"
 #include "linux/sdl_spi.h"
 #endif
+#elif defined(PICO_BOARD)
+#include "pico/io.h"
+#ifdef __cplusplus
+#include "pico/pico_spi.h"
+#include "pico/pico_i2c.h"
+#endif
 #else
 #warning "Platform is not supported. Use template to add support"
 #endif
@@ -485,6 +491,24 @@ public:
     }
 };
 
+#elif defined(PICO_BOARD)
+
+/**
+ * PlatformI2c implementation for current platform.
+ */
+class PlatformI2c: public PicoI2c
+{
+public:
+    /**
+     * Creates instance of i2c implementation for current platform.
+     * @param config i2c platform configuration. Refer to SPlatformI2cConfig.
+     */
+    explicit PlatformI2c(const SPlatformI2cConfig &config)
+        : PicoI2c(config.scl, config.sda, config.addr)
+    {
+    }
+};
+
 #else
 
 #error "Platform not supported"
@@ -615,6 +639,24 @@ public:
      */
     explicit PlatformSpi(const SPlatformSpiConfig &config)
         : UsiSpi(config.cs, config.dc)
+    {
+    }
+};
+
+#elif defined(PICO_BOARD)
+
+/**
+ * PlatformSpi implementation for current platform
+ */
+class PlatformSpi: public PicoSpi
+{
+public:
+    /**
+     * Creates instance of PlatformSpi implementation for current platform
+     * @param config spi platform configuration. Refer to SPlatformSpiConfig.
+     */
+    explicit PlatformSpi(const SPlatformSpiConfig &config)
+        : PicoSpi(config.cs, config.dc, config.scl, config.sda, config.frequency)
     {
     }
 };

--- a/src/lcd_hal/pico/io.h
+++ b/src/lcd_hal/pico/io.h
@@ -1,0 +1,38 @@
+/*
+    MIT License
+
+    Copyright (c) 2018-2022, Alexey Dynda
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+/*
+ * @file lcd_hal/pico/io.h Raspberry Pi Pico IO communication functions
+ */
+
+#pragma once
+
+// on Pico the `__in_flash()` is used, not compatible to `PROGMEM` macro
+#define LCD_PROGMEM
+
+#include "../UserSettings.h"
+#include "../interface.h"
+
+#include <string.h>
+#include <stdio.h>

--- a/src/lcd_hal/pico/pico_i2c.cpp
+++ b/src/lcd_hal/pico/pico_i2c.cpp
@@ -1,0 +1,77 @@
+/*
+    MIT License
+
+    Copyright (c) 2016-2020, Alexey Dynda
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+// !!!!! WARNING !!!!!!
+// This is a dummy implementation that does not work !!!
+#warning "I2C is not implemented for Pico board - this is a dummy"
+
+#include "../io.h"
+
+#if defined(PICO_BOARD)
+#include "pico_i2c.h"
+
+//////////////////////////////////////////////////////////////////////////////////
+//                        ARDUINO I2C IMPLEMENTATION
+//////////////////////////////////////////////////////////////////////////////////
+
+static uint8_t s_bytesWritten = 0;
+
+PicoI2c::PicoI2c(int8_t scl, int8_t sda, uint8_t sa)
+    : m_scl(scl)
+    , m_sda(sda)
+    , m_sa(sa)
+    , m_mode(0)
+{
+}
+
+PicoI2c::~PicoI2c()
+{
+}
+
+void PicoI2c::begin()
+{
+}
+
+void PicoI2c::end()
+{
+}
+
+void PicoI2c::start()
+{
+}
+
+void PicoI2c::stop()
+{
+}
+
+void PicoI2c::send(uint8_t data)
+{
+}
+
+void PicoI2c::sendBuffer(const uint8_t *buffer, uint16_t size)
+{
+}
+
+
+#endif // PICO_BOARD

--- a/src/lcd_hal/pico/pico_i2c.h
+++ b/src/lcd_hal/pico/pico_i2c.h
@@ -1,0 +1,107 @@
+/*
+    MIT License
+
+    Copyright (c) 2018-2019, Alexey Dynda
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+/*
+ * @file hal/pico/pico_i2c.h LCDGFX Raspberry Pi Pico Dummy !!! Interface
+ */
+
+// !!!!! WARNING !!!!!!
+// This is a dummy implementation that does not work !!!
+
+#pragma once
+
+
+#if defined(PICO_BOARD)
+/**
+ * Class implements i2c support via Wire library for Arduino platforms
+ */
+class PicoI2c
+{
+public:
+    /**
+     * Creates i2c implementation instance for Arduino platform.
+     * @param scl clock pin to use for i2c
+     * @param sda data pin to use for i2c
+     * @param sa i2c address of the device to control over i2c
+     */
+    PicoI2c(int8_t scl = -1, int8_t sda = -1, uint8_t sa = 0x00);
+    ~PicoI2c();
+
+    /**
+     * Initializes i2c interface
+     */
+    void begin();
+
+    /**
+     * Closes i2c interface
+     */
+    void end();
+
+    /**
+     * Starts communication with SSD1306 display.
+     */
+    void start();
+
+    /**
+     * Ends communication with SSD1306 display.
+     */
+    void stop();
+
+    /**
+     * Sends byte to SSD1306 device
+     * @param data - byte to send
+     */
+    void send(uint8_t data);
+
+    /**
+     * @brief Sends bytes to SSD1306 device
+     *
+     * Sends bytes to SSD1306 device. This functions gives
+     * ~ 30% performance increase than ssd1306_intf.send.
+     *
+     * @param buffer - bytes to send
+     * @param size - number of bytes to send
+     */
+    void sendBuffer(const uint8_t *buffer, uint16_t size);
+
+    /**
+     * Sets i2c address for communication
+     * This API is required for some led displays having multiple
+     * i2c addresses for different types of data.
+     *
+     * @param addr i2c address to set (7 bits)
+     */
+    void setAddr(uint8_t addr)
+    {
+        m_sa = addr;
+    }
+
+private:
+    int8_t m_scl;
+    int8_t m_sda;
+    uint8_t m_sa;
+    uint8_t m_mode;
+};
+
+#endif

--- a/src/lcd_hal/pico/pico_spi.cpp
+++ b/src/lcd_hal/pico/pico_spi.cpp
@@ -1,0 +1,72 @@
+/*
+    MIT License
+
+    Copyright (c) 2016-2022, Alexey Dynda
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+#include "../io.h"
+
+#if defined(PICO_BOARD)
+#include "pico_spi.h"
+//////////////////////////////////////////////////////////////////////////////////
+//                        PI PICO SPI IMPLEMENTATION
+//////////////////////////////////////////////////////////////////////////////////
+
+
+
+PicoSpi::PicoSpi(int8_t csPin, int8_t dcPin, int8_t clkPin, int8_t mosiPin, uint32_t frequency)
+    : m_cs(csPin)
+    , m_dc(dcPin)
+    , m_clk(clkPin)
+    , m_mosi(mosiPin)
+    , m_frequency(frequency)
+{
+}
+
+PicoSpi::~PicoSpi()
+{
+}
+
+void PicoSpi::begin()
+{
+}
+
+void PicoSpi::end()
+{
+}
+
+void PicoSpi::start()
+{
+}
+
+void PicoSpi::stop()
+{
+}
+
+void PicoSpi::send(uint8_t data)
+{
+}
+
+void PicoSpi::sendBuffer(const uint8_t *buffer, uint16_t size)
+{
+}
+
+#endif // PICO_BOARD

--- a/src/lcd_hal/pico/pico_spi.cpp
+++ b/src/lcd_hal/pico/pico_spi.cpp
@@ -25,7 +25,6 @@
 #include "../io.h"
 
 #if defined(PICO_BOARD)
-#include "pico_spi.h"
 //////////////////////////////////////////////////////////////////////////////////
 //                        PI PICO SPI IMPLEMENTATION
 //////////////////////////////////////////////////////////////////////////////////
@@ -47,26 +46,50 @@ PicoSpi::~PicoSpi()
 
 void PicoSpi::begin()
 {
+    if(m_cs >= 0) {
+        gpio_init(m_cs);
+        gpio_set_dir(m_cs, GPIO_OUT);
+        gpio_put(m_cs, 0);
+    };
+    if(m_dc >= 0) {
+        gpio_init(m_dc);
+        gpio_set_dir(m_dc, GPIO_OUT);
+        gpio_put(m_dc, 0);
+    };
+    
+    gpio_set_function(m_clk, GPIO_FUNC_SPI);
+    gpio_set_function(m_mosi, GPIO_FUNC_SPI);
+    // set SPI Mode 3; MSB first
+    spi_set_format(PICO_SPI, 8, SPI_CPOL_1, SPI_CPHA_1, SPI_MSB_FIRST);
+    spi_init(PICO_SPI, m_frequency);
 }
 
 void PicoSpi::end()
 {
+    spi_deinit(PICO_SPI);
 }
 
 void PicoSpi::start()
 {
+    if(m_cs >= 0)
+        gpio_put(m_cs, 0);
 }
 
 void PicoSpi::stop()
 {
+    if(m_cs >= 0)
+        gpio_put(m_cs, 1);
 }
 
 void PicoSpi::send(uint8_t data)
 {
+    
+    spi_write_blocking(PICO_SPI, &data, 1);
 }
 
 void PicoSpi::sendBuffer(const uint8_t *buffer, uint16_t size)
 {
+    spi_write_blocking(PICO_SPI, buffer, size);
 }
 
 #endif // PICO_BOARD

--- a/src/lcd_hal/pico/pico_spi.h
+++ b/src/lcd_hal/pico/pico_spi.h
@@ -1,0 +1,97 @@
+/*
+    MIT License
+
+    Copyright (c) 2018-2022, Alexey Dynda
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+/*
+ * @file hal/pico/pico_spi.h LCDGFX Raspberry Pi Pico Interface communication functions
+ */
+
+
+#pragma once
+
+#if defined(PICO_BOARD)
+
+
+/**
+ * Class implements SPI support for Arduino platforms
+ */
+class PicoSpi
+{
+public:
+    /**
+     * Creates instance of spi implementation for Arduino platform.
+     * @param csPin chip select pin to use, -1 if not required
+     * @param dcPin data command pin to use
+     * @param clkPin clk pin to use, -1 to use default. Doesn't work on all controllers
+     * @param mosiPin mosi pin to use, -1 to use default. Doesn't work on all controllers
+     * @param freq frequency in HZ to run spi bus at
+     */
+    PicoSpi(int8_t csPin = -1, int8_t dcPin = -1, int8_t clkPin = -1, int8_t mosiPin = -1, uint32_t freq = 0);
+    ~PicoSpi();
+
+    /**
+     * Initializes spi interface
+     */
+    void begin();
+
+    /**
+     * Closes spi interface
+     */
+    void end();
+
+    /**
+     * Starts communication with SSD1306 display.
+     */
+    void start();
+
+    /**
+     * Ends communication with SSD1306 display.
+     */
+    void stop();
+
+    /**
+     * Sends byte to SSD1306 device
+     * @param data - byte to send
+     */
+    void send(uint8_t data);
+
+    /**
+     * @brief Sends bytes to SSD1306 device
+     *
+     * Sends bytes to SSD1306 device. This functions gives
+     * ~ 30% performance increase than ssd1306_intf.send.
+     *
+     * @param buffer - bytes to send
+     * @param size - number of bytes to send
+     */
+    void sendBuffer(const uint8_t *buffer, uint16_t size);
+
+private:
+    int8_t m_cs;
+    int8_t m_dc;
+    int8_t m_clk;
+    int8_t m_mosi;
+    uint32_t m_frequency;
+};
+
+#endif

--- a/src/lcd_hal/pico/pico_spi.h
+++ b/src/lcd_hal/pico/pico_spi.h
@@ -30,7 +30,15 @@
 #pragma once
 
 #if defined(PICO_BOARD)
+#include "pico/stdlib.h"
+#include "hardware/spi.h"
 
+
+#if defined(PICO_USE_SPI1)
+#define PICO_SPI spi1
+#else
+#define PICO_SPI spi0
+#endif
 
 /**
  * Class implements SPI support for Arduino platforms

--- a/src/lcd_hal/pico/platform.cpp
+++ b/src/lcd_hal/pico/platform.cpp
@@ -25,54 +25,46 @@
 #include "../io.h"
 
 #if defined(PICO_BOARD)
-#include "pico_i2c.h"
 
-// !!!!! WARNING !!!!!!
-// This is a dummy implementation that does not work !!!
-#warning "I2C is not implemented for Pico board - this is a dummy"
-
-
-//////////////////////////////////////////////////////////////////////////////////
-//                        ARDUINO I2C IMPLEMENTATION
-//////////////////////////////////////////////////////////////////////////////////
-
-static uint8_t s_bytesWritten = 0;
-
-PicoI2c::PicoI2c(int8_t scl, int8_t sda, uint8_t sa)
-    : m_scl(scl)
-    , m_sda(sda)
-    , m_sa(sa)
-    , m_mode(0)
+void lcd_gpioMode(int pin, int mode)
 {
+    if(pin < 0)
+        return;
+    
+    gpio_init(pin);
+    switch(mode){
+        case LCD_GPIO_OUTPUT:
+            gpio_set_dir(pin, GPIO_OUT);
+            break;
+        case LCD_GPIO_INPUT:
+            gpio_set_dir(pin, GPIO_IN);
+            break;
+        case LCD_GPIO_INPUT_PULLUP:
+            gpio_set_dir(pin, GPIO_IN);
+            gpio_pull_up(pin);
+            break;
+        case LCD_GPIO_INPUT_PULLDOWN:
+            gpio_set_dir(pin, GPIO_IN);
+            gpio_pull_down(pin);;
+            break;
+    }
 }
 
-PicoI2c::~PicoI2c()
+void lcd_gpioWrite(int pin, int level)
 {
+    if (pin < 0)
+        return;
+    gpio_put(pin, level==LCD_HIGH);
 }
 
-void PicoI2c::begin()
+void lcd_delay(unsigned long ms)
 {
+    sleep_ms(ms);
 }
 
-void PicoI2c::end()
+uint8_t lcd_pgmReadByte(const void *ptr)
 {
+    return *(static_cast<const uint8_t *>(ptr));
 }
 
-void PicoI2c::start()
-{
-}
-
-void PicoI2c::stop()
-{
-}
-
-void PicoI2c::send(uint8_t data)
-{
-}
-
-void PicoI2c::sendBuffer(const uint8_t *buffer, uint16_t size)
-{
-}
-
-
-#endif // PICO_BOARD
+#endif


### PR DESCRIPTION
HAL implementation for the Raspberry Pi Pico Microcontroller.

- SPI implementation is tested using hardware.
- I2C is not yet implemented. Only en empty framework is provided, as well as an precompiler warning
- An examples for using the lcdgfx library from a Raspberry Pi Pico prject via CMake is provided as well

A issue was created first with further explanations, as stated in the Pull Request Process:
https://github.com/lexus2k/lcdgfx/issues/116#issue-2269758949