### PR TITLE
Fix convert from UTF-8 to Unicode

### DIFF
--- a/src/canvas/font.cpp
+++ b/src/canvas/font.cpp
@@ -330,10 +330,10 @@ lcduint_t NanoFont::getTextSize(const char *text, lcduint_t *height)
 uint16_t NanoFont::unicode16FromUtf8(uint8_t ch)
 {
 #ifdef CONFIG_SSD1306_UNICODE_ENABLE
-    static uint16_t unicode = 0;
-    static uint8_t rest = 0;
     if(ch & 0x80)
     {
+        static uint16_t unicode = 0;
+        static uint8_t rest = 0;
         if(ch & 0x40)
         {
             uint8_t mask = 0x1f;


### PR DESCRIPTION
Before this, we can only display U+0000 to U+07EE, since only 1-byte and 2-byte UTF-8 characters were considered. After this, we can use U+0000 to U+FFFF.
This Pull Request is made to solve issue #122