### PR TITLE
Define CONFIG_ESP32_SPI_AVAILABLE if ESP32 is defined

### DIFF
--- a/src/lcd_hal/arduino/io.h
+++ b/src/lcd_hal/arduino/io.h
@@ -126,12 +126,13 @@ typedef uint8_t lcduint_t;
 /** The macro is defined when SPI library is available */
 #define CONFIG_ARDUINO_SPI_AVAILABLE
 
-#define CONFIG_ESP32_SPI_AVAILABLE
 
 #if defined(ESP32)
 /** The macro is defined when ESP32 spi implementation is available */
+#define CONFIG_ESP32_SPI_AVAILABLE
+/** The macro is defined when ESP32 spi2 implementation is available */
 #define CONFIG_ARDUINO_SPI2_AVAILABLE
-/** The macro is defined when composite audio support is available */
+/** The macro is defined when VGA monitor control is available directly from controller */
 #define CONFIG_VGA_AVAILABLE
 #endif
 


### PR DESCRIPTION
It looks like this def was placed in too broad a scope in 1e25600

I don't have an esp32 handy to test on however it should still be defined on an ESP32. The ESP31B will no longer have it defined. This was a beta chip and I cannot find information if it supports SPI2.

I also fixed a comment that was incorrect since the initial commit.

fixes https://github.com/lexus2k/lcdgfx/issues/88
fixes https://github.com/lexus2k/lcdgfx/issues/111 
fixes https://github.com/lexus2k/lcdgfx/issues/93