### PR TITLE
Fix esp8266_spi compilation

### DIFF
--- a/src/lcd_hal/esp/esp8266_spi.cpp
+++ b/src/lcd_hal/esp/esp8266_spi.cpp
@@ -174,7 +174,7 @@ void EspSpi::forceSpiTransfer()
         spi_trans_t t{};
         t.bits.mosi = 8 * sz; // 8 bits
         t.mosi = reinterpret_cast<uint32_t *>(buffer);
-        spi_trans(m_spi, t);
+        spi_trans(m_spi, &t);
         buffer += sz;
         m_data_size -= sz;
     }


### PR DESCRIPTION
Compilation for esp8266 is failing:

```
CXX build/lcdgfx/src/lcd_hal/esp/esp8266_spi.o
/home/jon/Development/ssd1306_test/components/lcdgfx/src/lcd_hal/esp/esp8266_spi.cpp: In member function 'void EspSpi::forceSpiTransfer()':
/home/jon/Development/ssd1306_test/components/lcdgfx/src/lcd_hal/esp/esp8266_spi.cpp:177:26: error: cannot convert 'spi_trans_t' to 'spi_trans_t*'
         spi_trans(m_spi, t);
                          ^
In file included from /home/jon/Development/ssd1306_test/components/lcdgfx/src/lcd_hal/esp/../esp/esp8266_spi.h:34,
                 from /home/jon/Development/ssd1306_test/components/lcdgfx/src/lcd_hal/esp/../io.h:74,
                 from /home/jon/Development/ssd1306_test/components/lcdgfx/src/lcd_hal/esp/esp8266_spi.cpp:25:
/home/jon/esp/ESP8266_RTOS_SDK/components/esp8266/include/driver/spi.h:413:51: note:   initializing argument 2 of 'esp_err_t spi_trans(spi_host_t, spi_trans_t*)'
 esp_err_t spi_trans(spi_host_t host, spi_trans_t *trans);
                                      ~~~~~~~~~~~~~^~~~~
make[1]: *** [/home/jon/esp/ESP8266_RTOS_SDK/make/component_wrapper.mk:292: src/lcd_hal/esp/esp8266_spi.o] Error 1
make: *** [/home/jon/esp/ESP8266_RTOS_SDK//make/project.mk:571: component-lcdgfx-build] Error 2
```

This corrects the call to spi_trans() by passing in a pointer to the spi_trans_t structure.